### PR TITLE
Remove binaryio dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/takurooo/wavgo
 go 1.21
 
 require (
-	github.com/stretchr/testify v1.9.0
-	github.com/takurooo/binaryio v0.0.0-20200902134553-3646975c5920
+        github.com/stretchr/testify v1.9.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/takurooo/binaryio v0.0.0-20200902134553-3646975c5920 h1:UPDbzTXMqCkpRGUritCaoo4HS3cBSAMViRP1I5ecvy4=
-github.com/takurooo/binaryio v0.0.0-20200902134553-3646975c5920/go.mod h1:liCc/Mqk18dyq1CLtKTzL2eP7/Wjq8pg3597n/Yq4R8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/binio/reader.go
+++ b/internal/binio/reader.go
@@ -1,0 +1,82 @@
+package binio
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type Reader struct {
+	r   io.ReaderAt
+	off int64
+	err error
+}
+
+func NewReader(r io.ReaderAt) *Reader {
+	return &Reader{r: r}
+}
+
+func (br *Reader) read(n int) []byte {
+	if br.err != nil {
+		return nil
+	}
+	buf := make([]byte, n)
+	_, err := br.r.ReadAt(buf, br.off)
+	if err != nil {
+		br.err = err
+		return nil
+	}
+	br.off += int64(n)
+	return buf
+}
+
+func (br *Reader) ReadRaw(n uint64) []byte {
+	return br.read(int(n))
+}
+
+func (br *Reader) ReadU8() uint8 {
+	b := br.read(1)
+	if br.err != nil {
+		return 0
+	}
+	return b[0]
+}
+
+func (br *Reader) ReadU16(order binary.ByteOrder) uint16 {
+	b := br.read(2)
+	if br.err != nil {
+		return 0
+	}
+	return order.Uint16(b)
+}
+
+func (br *Reader) ReadU24(order binary.ByteOrder) uint32 {
+	b := br.read(3)
+	if br.err != nil {
+		return 0
+	}
+	if order == binary.LittleEndian {
+		return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16
+	}
+	return uint32(b[2]) | uint32(b[1])<<8 | uint32(b[0])<<16
+}
+
+func (br *Reader) ReadU32(order binary.ByteOrder) uint32 {
+	b := br.read(4)
+	if br.err != nil {
+		return 0
+	}
+	return order.Uint32(b)
+}
+
+func (br *Reader) ReadS32(order binary.ByteOrder) string {
+	_ = order // order is ignored for strings
+	b := br.read(4)
+	if br.err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func (br *Reader) Err() error {
+	return br.err
+}

--- a/internal/binio/writer.go
+++ b/internal/binio/writer.go
@@ -1,0 +1,91 @@
+package binio
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type Writer struct {
+	w      io.WriteSeeker
+	offset int64
+	err    error
+}
+
+func NewWriter(w io.WriteSeeker) *Writer {
+	return &Writer{w: w}
+}
+
+func (bw *Writer) write(b []byte) {
+	if bw.err != nil {
+		return
+	}
+	n, err := bw.w.Write(b)
+	if err != nil {
+		bw.err = err
+		return
+	}
+	if n != len(b) {
+		bw.err = io.ErrShortWrite
+		return
+	}
+	bw.offset += int64(n)
+}
+
+func (bw *Writer) WriteU8(v uint8) {
+	bw.write([]byte{v})
+}
+
+func (bw *Writer) WriteU16(v uint16, order binary.ByteOrder) {
+	buf := make([]byte, 2)
+	order.PutUint16(buf, v)
+	bw.write(buf)
+}
+
+func (bw *Writer) WriteU24(v uint32, order binary.ByteOrder) {
+	buf := make([]byte, 3)
+	if order == binary.LittleEndian {
+		buf[0] = byte(v)
+		buf[1] = byte(v >> 8)
+		buf[2] = byte(v >> 16)
+	} else {
+		buf[2] = byte(v)
+		buf[1] = byte(v >> 8)
+		buf[0] = byte(v >> 16)
+	}
+	bw.write(buf)
+}
+
+func (bw *Writer) WriteU32(v uint32, order binary.ByteOrder) {
+	buf := make([]byte, 4)
+	order.PutUint32(buf, v)
+	bw.write(buf)
+}
+
+func (bw *Writer) WriteS32(s string, order binary.ByteOrder) {
+	_ = order // order is ignored for strings
+	if len(s) != 4 {
+		bw.err = io.ErrShortWrite
+		return
+	}
+	bw.write([]byte(s))
+}
+
+func (bw *Writer) SetOffset(off int64) {
+	if bw.err != nil {
+		return
+	}
+	_, err := bw.w.Seek(off, io.SeekStart)
+	if err != nil {
+		bw.err = err
+		return
+	}
+	bw.offset = off
+}
+
+func (bw *Writer) GetOffset() int64 {
+	return bw.offset
+}
+
+func (bw *Writer) Err() error {
+	return bw.err
+}

--- a/internal/riff/reader.go
+++ b/internal/riff/reader.go
@@ -1,21 +1,22 @@
 package riff
 
 import (
+	"encoding/binary"
 	"errors"
 	"io"
 
-	"github.com/takurooo/binaryio"
+	"github.com/takurooo/wavgo/internal/binio"
 )
 
 func ReadRIFFChunk(r io.ReaderAt) (*riffChunk, error) {
-	breader := binaryio.NewReader(r)
+	breader := binio.NewReader(r)
 	// ----------------------------
 	// Read RIFF Chunk
 	// ----------------------------
 	var (
-		chunkID   = breader.ReadS32(binaryio.BigEndian)
-		chunkSize = breader.ReadU32(binaryio.LittleEndian)
-		format    = breader.ReadS32(binaryio.BigEndian)
+		chunkID   = breader.ReadS32(binary.BigEndian)
+		chunkSize = breader.ReadU32(binary.LittleEndian)
+		format    = breader.ReadS32(binary.BigEndian)
 	)
 	if breader.Err() != nil {
 		return nil, breader.Err()
@@ -30,8 +31,8 @@ func ReadRIFFChunk(r io.ReaderAt) (*riffChunk, error) {
 	numBytesLeft := riffChunk.Size - 4
 	for 0 < numBytesLeft {
 		var (
-			subChunkID   = breader.ReadS32(binaryio.BigEndian)
-			subChunkSize = breader.ReadU32(binaryio.LittleEndian)
+			subChunkID   = breader.ReadS32(binary.BigEndian)
+			subChunkSize = breader.ReadU32(binary.LittleEndian)
 			chunkData    = breader.ReadRaw(uint64(subChunkSize))
 		)
 		if breader.Err() != nil {

--- a/reader.go
+++ b/reader.go
@@ -2,10 +2,11 @@ package wavgo
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"os"
 
-	"github.com/takurooo/binaryio"
+	"github.com/takurooo/wavgo/internal/binio"
 	"github.com/takurooo/wavgo/internal/riff"
 )
 
@@ -15,7 +16,7 @@ type Reader struct {
 	format         Format
 	numSamples     uint32
 	numSamplesLeft uint32
-	br             *binaryio.Reader
+	br             *binio.Reader
 }
 
 // NewReader ...
@@ -68,7 +69,7 @@ func (r *Reader) ReadOnMemory() error {
 	}
 	r.numSamples = dataChunk.Size / uint32(r.format.BlockAlign)
 	r.numSamplesLeft = r.numSamples
-	r.br = binaryio.NewReader(bytes.NewReader(dataChunk.Data))
+	r.br = binio.NewReader(bytes.NewReader(dataChunk.Data))
 	return nil
 }
 
@@ -100,11 +101,11 @@ func (r *Reader) GetSamples(numSamples int) ([]Sample, error) {
 			case 8:
 				v = int(r.br.ReadU8())
 			case 16:
-				v = int(r.br.ReadU16(binaryio.LittleEndian))
+				v = int(r.br.ReadU16(binary.LittleEndian))
 			case 24:
-				v = int(r.br.ReadU24(binaryio.LittleEndian))
+				v = int(r.br.ReadU24(binary.LittleEndian))
 			case 32:
-				v = int(r.br.ReadU32(binaryio.LittleEndian))
+				v = int(r.br.ReadU32(binary.LittleEndian))
 			default:
 				return nil, errors.New("not supported BitsPerSample")
 			}
@@ -121,14 +122,14 @@ func (r *Reader) GetSamples(numSamples int) ([]Sample, error) {
 }
 
 func parseFormatChunkData(fmtChunk *riff.Chunk) (Format, error) {
-	br := binaryio.NewReader(bytes.NewReader(fmtChunk.Data))
+	br := binio.NewReader(bytes.NewReader(fmtChunk.Data))
 	format := Format{
-		AudioFormat:   br.ReadU16(binaryio.LittleEndian),
-		NumChannels:   br.ReadU16(binaryio.LittleEndian),
-		SampleRate:    br.ReadU32(binaryio.LittleEndian),
-		ByteRate:      br.ReadU32(binaryio.LittleEndian),
-		BlockAlign:    br.ReadU16(binaryio.LittleEndian),
-		BitsPerSample: br.ReadU16(binaryio.LittleEndian),
+		AudioFormat:   br.ReadU16(binary.LittleEndian),
+		NumChannels:   br.ReadU16(binary.LittleEndian),
+		SampleRate:    br.ReadU32(binary.LittleEndian),
+		ByteRate:      br.ReadU32(binary.LittleEndian),
+		BlockAlign:    br.ReadU16(binary.LittleEndian),
+		BitsPerSample: br.ReadU16(binary.LittleEndian),
 	}
 	if br.Err() != nil {
 		return Format{}, br.Err()


### PR DESCRIPTION
## Summary
- replace binaryio usage with new internal/binio package
- update reader and writer implementations
- drop binaryio from go.mod and go.sum

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/github.com/stretchr/testify/...": connect: no route to host)*