### PR TITLE
Rename ReadOnMemory to Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ func main() {
     defer r.Close()
 
     // read and parse wave file
-    err = r.ReadOnMemory()
+    err = r.Load()
     if err != nil {
         panic(err)
     }

--- a/reader.go
+++ b/reader.go
@@ -39,8 +39,8 @@ func (r *Reader) Close() {
 	r.f.Close()
 }
 
-// ReadOnMemory ...
-func (r *Reader) ReadOnMemory() error {
+// Load reads and parses the WAV file into memory.
+func (r *Reader) Load() error {
 	// ----------------------------
 	// RIFF Chunk
 	// ----------------------------

--- a/reader_test.go
+++ b/reader_test.go
@@ -13,7 +13,7 @@ func TestReader(t *testing.T) {
 	require.Nil(t, err)
 	defer r.Close()
 
-	err = r.ReadOnMemory()
+	err = r.Load()
 	require.Nil(t, err)
 
 	format := r.GetFormat()


### PR DESCRIPTION
## Summary
- rename method ReadOnMemory -> Load for clarity
- update README example accordingly
- update unit tests for new method name

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*