### PR TITLE
Propagate reader close error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ func main() {
     if err = r.Open("/path/to/your/file.wav"); err != nil {
         panic(err)
     }
-    defer r.Close()
+    defer func() {
+        if err := r.Close(); err != nil {
+            panic(err)
+        }
+    }()
 
     // read and parse wave file
     err = r.Load()

--- a/reader.go
+++ b/reader.go
@@ -35,8 +35,11 @@ func (r *Reader) Open(filePath string) error {
 }
 
 // Close ...
-func (r *Reader) Close() {
-	r.f.Close()
+func (r *Reader) Close() error {
+	if r.f == nil {
+		return nil
+	}
+	return r.f.Close()
 }
 
 // Load reads and parses the WAV file into memory.

--- a/reader_test.go
+++ b/reader_test.go
@@ -11,7 +11,10 @@ func TestReader(t *testing.T) {
 	r := NewReader()
 	err = r.Open("testdata/read_test.wav")
 	require.Nil(t, err)
-	defer r.Close()
+	defer func() {
+		cerr := r.Close()
+		require.Nil(t, cerr)
+	}()
 
 	err = r.Load()
 	require.Nil(t, err)


### PR DESCRIPTION
## Summary
- return error from `Reader.Close`
- check `Reader.Close` errors in tests
- update README example to handle `Reader.Close` error

## Testing
- `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy GOPROXY=direct go test ./...` *(fails: could not resolve host github.com)*