### PR TITLE
Introduce ErrUnsupportedBitsPerSample

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,6 @@
+package wavgo
+
+import "errors"
+
+// ErrUnsupportedBitsPerSample is returned when the number of bits per sample is not supported.
+var ErrUnsupportedBitsPerSample = errors.New("unsupported BitsPerSample")

--- a/reader.go
+++ b/reader.go
@@ -3,7 +3,6 @@ package wavgo
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"os"
 
 	"github.com/takurooo/wavgo/internal/binio"
@@ -107,7 +106,7 @@ func (r *Reader) GetSamples(numSamples int) ([]Sample, error) {
 			case 32:
 				v = int(r.br.ReadU32(binary.LittleEndian))
 			default:
-				return nil, errors.New("not supported BitsPerSample")
+				return nil, ErrUnsupportedBitsPerSample
 			}
 
 			if r.br.Err() != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,6 +1,7 @@
 package wavgo
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,4 +38,19 @@ func TestReader(t *testing.T) {
 	require.Equal(t, 3, samples[1][0])
 	require.Equal(t, 4, samples[1][1])
 	require.Equal(t, uint32(0), r.GetNumSamplesLeft())
+}
+
+func TestReaderUnsupportedBitsPerSample(t *testing.T) {
+	r := NewReader()
+	err := r.Open("testdata/read_test.wav")
+	require.NoError(t, err)
+	defer r.Close()
+
+	err = r.Load()
+	require.NoError(t, err)
+
+	r.format.BitsPerSample = 7
+	samples, err := r.GetSamples(1)
+	require.Nil(t, samples)
+	require.True(t, errors.Is(err, ErrUnsupportedBitsPerSample))
 }

--- a/writer.go
+++ b/writer.go
@@ -2,7 +2,6 @@ package wavgo
 
 import (
 	"encoding/binary"
-	"errors"
 	"os"
 
 	"github.com/takurooo/wavgo/internal/binio"
@@ -110,7 +109,7 @@ func (w *Writer) WriteSamples(samples []Sample) error {
 			case 32:
 				w.bw.WriteU32(uint32(sample[ch]), binary.LittleEndian)
 			default:
-				return errors.New("not supported BitsPerSample")
+				return ErrUnsupportedBitsPerSample
 			}
 
 			if w.bw.Err() != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,6 +1,7 @@
 package wavgo
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -44,4 +45,27 @@ func TestWriter(t *testing.T) {
 	want, err := os.ReadFile("testdata/write_test.wav.golden")
 	require.Nil(t, err)
 	require.Equal(t, want, b)
+}
+
+func TestWriterUnsupportedBitsPerSample(t *testing.T) {
+	format := &Format{
+		AudioFormat:   AudioFormatPCM,
+		NumChannels:   2,
+		SampleRate:    48000,
+		ByteRate:      128000,
+		BlockAlign:    4,
+		BitsPerSample: 7,
+	}
+
+	w := NewWriter(format)
+	err := w.Open("testdata/write_unsupported.wav")
+	require.NoError(t, err)
+	defer func() {
+		w.Close()
+		os.Remove("testdata/write_unsupported.wav")
+	}()
+
+	samples := make([]Sample, 1)
+	err = w.WriteSamples(samples)
+	require.True(t, errors.Is(err, ErrUnsupportedBitsPerSample))
 }


### PR DESCRIPTION
## Summary
- add `ErrUnsupportedBitsPerSample` error
- use the new error in `Reader` and `Writer`
- test `ErrUnsupportedBitsPerSample` with `errors.Is`

## Testing
- `go test ./...` *(fails: cannot download github.com/stretchr/testify)*